### PR TITLE
Fix error message when reference bins not found

### DIFF
--- a/reference_bins.py
+++ b/reference_bins.py
@@ -90,7 +90,7 @@ class ReferenceBins:
 				file_in.close()
 			
 		except IOError:
-		   stop_err("Reference bin could not be found or opened: " + self.path + bin_folder_name + '/accession_ids.tab')
+		   common.stop_err("Reference bin could not be found or opened: " + bin.file_path)
 		
 		return bin
 


### PR DESCRIPTION
When a reference bins file isn't found, this error is triggered. But there are a couple problems with how the error message is generated:

1. `stop_err` is provided by the `common` module.
2. The `ReferenceBins` class has no field `path`.

Fixes #4 